### PR TITLE
Remove dept-level grade detail tables

### DIFF
--- a/html_generator.py
+++ b/html_generator.py
@@ -715,14 +715,6 @@ def plot_selected_depts(df: pd.DataFrame, out_dir: Path, selected_depts: list = 
                             <div class="plot-container" id="plot-{plot_counter}"></div>
                         </div>
                         {plot_script}
-                        <div class="stats-tables-wrapper">
-                            <div id="conv-additional-stats-{plot_counter}" class="additional-stats-container">
-                                {conv_detail_stats}
-                            </div>
-                            <div id="all-subj-additional-stats-{plot_counter}" class="additional-stats-container" style="display:none;">
-                                {all_subj_detail_stats}
-                            </div>
-                        </div>
                     </div>
                 </div>
                 """
@@ -748,14 +740,6 @@ def plot_selected_depts(df: pd.DataFrame, out_dir: Path, selected_depts: list = 
                         <div class="plot-container" id="plot-{plot_counter}"></div>
                     </div>
                     {plot_script}
-                    <div class="stats-tables-wrapper">
-                        <div id="conv-additional-stats-{plot_counter}" class="additional-stats-container">
-                            {conv_detail_stats}
-                        </div>
-                        <div id="all-subj-additional-stats-{plot_counter}" class="additional-stats-container" style="display:none;">
-                            {all_subj_detail_stats}
-                        </div>
-                    </div>
                 </div>
             </div>
             """
@@ -809,14 +793,6 @@ def plot_selected_depts(df: pd.DataFrame, out_dir: Path, selected_depts: list = 
                             <div class="plot-container" id="plot-{plot_counter}"></div>
                         </div>
                         {plot_script}
-                        <div class="stats-tables-wrapper">
-                            <div id="conv-additional-stats-{plot_counter}" class="additional-stats-container">
-                                {conv_detail_stats}
-                            </div>
-                            <div id="all-subj-additional-stats-{plot_counter}" class="additional-stats-container" style="display:none;">
-                                {all_subj_detail_stats}
-                            </div>
-                        </div>
                     </div>
                 </div>
             """


### PR DESCRIPTION
## Summary
- remove the additional grade statistics tables from department and subtype sections
- keep the detailed tables for the overall summary section

## Testing
- `python test_html_generator.py` *(fails: ModuleNotFoundError: No module named 'pandas')*