### PR TITLE
Add center team header

### DIFF
--- a/html_generator.py
+++ b/html_generator.py
@@ -613,6 +613,7 @@ def plot_selected_depts(
             body, html {{ margin:0; padding:0; font-family:'Malgun Gothic', '맑은 고딕', sans-serif; background-color: #f4f7f6; }}
             .fixed-header {{ position: sticky; top: 0; background-color: white; padding: 10px 0; box-shadow: 0 2px 10px rgba(0,0,0,0.1); z-index: 1000; width: 100%; border-bottom: 1px solid #ddd; }}
             .header-content {{ max-width: 1200px; margin: 0 auto; padding: 0 20px; display: flex; flex-direction: column; align-items: center; }}
+            .site-title {{ font-size: 18px; font-weight: bold; color: #555; margin-bottom: 5px; }}
             .university-title {{ text-align: center; font-size: 24px; margin: 10px 0 15px; font-weight: bold; color: #333; }}
             .controls-legend-wrapper {{ display: flex; justify-content: space-between; align-items: center; width: 100%; margin-bottom: 10px; flex-wrap: wrap; }}
             .grade-toggle-container {{ padding: 10px; background-color: #f8f8f8; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); flex: 1; min-width: 280px; margin-right: 10px; text-align: center; }}
@@ -724,6 +725,7 @@ def plot_selected_depts(
     <body>
         <div class="fixed-header">
             <div class="header-content">
+                <div class="site-title">강원진학센터 입시분석팀</div>
                 <div class="university-title">선택된 모집단위 입시 결과</div>
                 <div class="controls-legend-wrapper">
                     <div class="grade-toggle-container">

--- a/main.py
+++ b/main.py
@@ -56,6 +56,13 @@ class DepartmentSelector(tk.Tk):
         self.main_frame = ttk.Frame(self, padding=15)
         self.main_frame.pack(fill=tk.BOTH, expand=True)
 
+        # ── 타이틀 표시 ─────────────────────────────────────────
+        ttk.Label(
+            self.main_frame,
+            text="강원진학센터 입시분석팀",
+            font=("Helvetica", 16, "bold"),
+        ).pack(pady=(0, 10))
+
         # ── 입력 파일 선택 ───────────────────────────────────
         top_frame = ttk.LabelFrame(self.main_frame, text="입력 파일 선택", padding=10)
         top_frame.pack(fill=tk.X, pady=(0, 15))


### PR DESCRIPTION
## Summary
- show the text '강원진학센터 입시분석팀' in the GUI main window
- display the same team name at the top of generated HTML reports

## Testing
- `pytest -q` *(fails: command not found)*
- `python test_html_generator.py` *(fails: No module named 'pandas')*