### PR TITLE
Show university name in scatter plot tooltips

### DIFF
--- a/html_generator.py
+++ b/html_generator.py
@@ -486,12 +486,12 @@ def create_plot_data_script(plot_id, data, y_positions, marker_styles, symbol_ma
             conv_rows = result_data.dropna(subset=["conv_grade"])
             x_values_json = json.dumps(conv_rows["conv_grade"].tolist(), cls=NumpyEncoder)
             y_values_json = json.dumps([y_positions.get(result, 0)] * len(conv_rows))
-            customdata_json = json.dumps(list(zip(conv_rows["dept"], conv_rows["subtype"])), cls=NumpyEncoder)
+            customdata_json = json.dumps(list(zip(conv_rows["dept"], conv_rows["subtype"], conv_rows["univ"])), cls=NumpyEncoder)
             conv_traces.append(f"""{{
                 x: {x_values_json}, y: {y_values_json}, type: 'scatter', mode: 'markers', name: '{result}',
                 marker: {{ color: '{color_map[result]["fill"]}', line: {{color: '{color_map[result]["border"]}', width: 1.5}}, symbol: '{symbol_map.get(result, "circle")}', size: 12 }},
                 customdata: {customdata_json},
-                hovertemplate: '환산등급: %{{x}}<br>모집단위: %{{customdata[0]}}<br>세부유형: %{{customdata[1]}}<extra></extra>'
+                hovertemplate: '환산등급: %{{x}}<br>대학: %{{customdata[2]}}<br>모집단위: %{{customdata[0]}}<br>세부유형: %{{customdata[1]}}<extra></extra>'
             }}""")
 # 평균값을 표시하는 텍스트 트레이스 추가 (제거됨)
             # conv_means_traces.append(f"""{{
@@ -522,12 +522,12 @@ def create_plot_data_script(plot_id, data, y_positions, marker_styles, symbol_ma
             subj_rows = result_data.dropna(subset=["all_subj_grade"])
             x_values_json = json.dumps(subj_rows["all_subj_grade"].tolist(), cls=NumpyEncoder)
             y_values_json = json.dumps([y_positions.get(result, 0)] * len(subj_rows))
-            customdata_json = json.dumps(list(zip(subj_rows["dept"], subj_rows["subtype"])), cls=NumpyEncoder)
+            customdata_json = json.dumps(list(zip(subj_rows["dept"], subj_rows["subtype"], subj_rows["univ"])), cls=NumpyEncoder)
             all_subj_traces.append(f"""{{
                 x: {x_values_json}, y: {y_values_json}, type: 'scatter', mode: 'markers', name: '{result}',
                 marker: {{ color: '{color_map[result]["fill"]}', line: {{color: '{color_map[result]["border"]}', width: 1.5}}, symbol: '{symbol_map.get(result, "circle")}', size: 12 }},
                 customdata: {customdata_json},
-                hovertemplate: '전교과등급: %{{x}}<br>모집단위: %{{customdata[0]}}<br>세부유형: %{{customdata[1]}}<extra></extra>'
+                hovertemplate: '전교과등급: %{{x}}<br>대학: %{{customdata[2]}}<br>모집단위: %{{customdata[0]}}<br>세부유형: %{{customdata[1]}}<extra></extra>'
             }}""")
 # 평균값을 표시하는 텍스트 트레이스 추가 (제거됨)
             # all_subj_means_traces.append(f"""{{


### PR DESCRIPTION
## Summary
- update hover info to include university name

## Testing
- `pytest -q` *(fails: command not found)*